### PR TITLE
Fix link in schedule

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -100,7 +100,7 @@ layout: default
 
       <td>Domain specific languages in Racket</td>
 
-      <td><a href="slides/slides05.pdf">slides</a></td>            
+      <td><a href="slides/slides07.pdf">slides</a></td>            
 
       <td></td>
     </tr>


### PR DESCRIPTION
The link to the slides for lecture 7 pointed to the slides for lecture 5.